### PR TITLE
リダイレクト先の設定

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,7 @@
 class ItemsController < ApplicationController
   before_action :set_item, only: [:update, :edit, :show,:destroy]
   before_action :set_category, only: [:new, :update, :edit, :show]
+  before_action :move_to_index, except: [:index,:show]
 
   def index
     @parents = Category.where(ancestry: nil)
@@ -108,7 +109,9 @@ class ItemsController < ApplicationController
 
   def set_item
     @item = Item.find(params[:id])
-    # @imgs = Image.where(item_id: params[:id]) 
-    # binding.pry
+  end
+
+  def move_to_index
+    redirect_to action: :index unless @item.user.id==current_user.id
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,6 @@
 class UsersController < ApplicationController
   def show
     @parents = Category.where(ancestry: nil)
+    redirect_to new_user_registration_path unless user_signed_in?
   end
 end


### PR DESCRIPTION
What
・ログインしていないユーザーが商品一覧・商品詳細以外のページへ行こうとしたらログインページへリダイレクトさせる
・他人の商品の編集画面へURLを直打ちしても飛べないようになっている
Why
悪意のあるユーザーからの不正なアクセスを防止する為